### PR TITLE
Version bump & new webProps option

### DIFF
--- a/.changeset/old-dogs-juggle.md
+++ b/.changeset/old-dogs-juggle.md
@@ -1,0 +1,15 @@
+---
+"@waveplay/pilot": minor
+---
+
+feat: props can now be loaded via Next.js API routes
+
+feat: new `createHandler` export from `@waveplay/pilot/api` to create a Next.js API route handler
+
+refactor: renamed internal "getProps" to "getPropsType" in generated files
+
+refactor: reorganized internal packages for better bundling (does not affect external usage)
+
+chore: node engine version bump & cleaned up package.json
+
+feat: new webProps option to control how prop loading works

--- a/.changeset/polite-bugs-wink.md
+++ b/.changeset/polite-bugs-wink.md
@@ -1,0 +1,15 @@
+---
+"pilotjs-cli": minor
+---
+
+feat: CLI now also reads next.config.js for i18n config
+
+feat: auto remove cache during builds
+
+chore: node engine version bump & cleaned up package.json
+
+feat: pilot.config.js can now be used to provide a default runtime config
+
+refactor: renamed internal "getProps" to "getPropsType" in generated files
+
+fix: exclude api routes from generated pages

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.0.0-canary-20221113041838
+
+### Patch Changes
+
+- Updated dependencies
+  - @waveplay/pilot@0.0.0-canary-20221113041838
+
 ## 0.0.0-canary-20221111071730
 
 ### Patch Changes
@@ -65,6 +72,7 @@
 - c7182c2: fix: exclude api routes from generated pages
 - Updated dependencies [2bb228b]
   - @waveplay/pilot@0.0.0-canary-20221108091630
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pilotjs-cli",
-	"version": "0.0.0-canary-20221111071730",
+	"version": "0.0.0-canary-20221113041838",
 	"private": false,
 	"description": "NextJS-like routing for React Native",
 	"repository": {
@@ -39,7 +39,7 @@
 	"bin": "dist/index.js",
 	"dependencies": {
 		"@swc/core": "1.3.8",
-		"@waveplay/pilot": "0.0.0-canary-20221111070614",
+		"@waveplay/pilot": "0.0.0-canary-20221113041838",
 		"app-root-path": "3.1.0",
 		"benchmark": "2.1.4",
 		"commander": "9.4.1",

--- a/packages/pilot/src/client/core/pilot.ts
+++ b/packages/pilot/src/client/core/pilot.ts
@@ -376,7 +376,7 @@ export class Pilot {
 		// This will emulate a NextJS page load, but without the usual server parameters, so be aware
 		let props: any;
 		try {
-			props = await this._loadProps(path, route);
+			props = await this._loadProps(path, route, options);
 		} catch (e) {
 			this.log('error', `Error loading props for path: ${path}`, e);
 			this._notify(path, { error: e, type: 'error' });
@@ -423,7 +423,8 @@ export class Pilot {
 	 * @param route Route for the specified path.
 	 * @returns Props for the specified path.
 	 */
-	private async _loadProps(path: string, route: PilotRouteResult): Promise<any> {
+	private async _loadProps(path: string, route: PilotRouteResult, options?: PilotFlyOptions): Promise<any> {
+		const { webProps = 'auto' } = options ?? {};
 		let props: any = null;
 
 		// Return early if there's nothing to load
@@ -431,7 +432,7 @@ export class Pilot {
 			return props;
 		}
 
-		if (this._config.host) {
+		if (webProps === 'always' || (webProps === 'auto' && this._config.host)) {
 			this.log('debug', `Loading props remotely for path:`, path);
 			const response = await fetch(this._config.host + '/api/pilot/get-props', {
 				method: 'POST',

--- a/packages/pilot/src/client/types.ts
+++ b/packages/pilot/src/client/types.ts
@@ -32,6 +32,17 @@ export interface PilotFlyOptions {
 	locale?: string | false
 	scroll?: boolean
 	shallow?: boolean
+
+	/**
+	 * Decides when to load props using the web version of this app.
+	 * 
+	 * `'always'` - Always load props using the web version of this app. Will fail if not available or set up.
+	 * 
+	 * `'auto'` - Will load props using the web version of this app only as long as it's set up. (`host` in config)
+	 * 
+	 * `'never'` - Will instead load props using the native app's runtime. Be careful when using Node APIs or environment secrets with this option.
+	*/
+	webProps?: 'always' | 'auto' | 'never'
 }
 
 export interface PilotEvent {


### PR DESCRIPTION
Sometimes you may want to override default behavior and load props natively despite having a "host" option available.

Default behavior is "auto", but you can choose "always" to force remote loading even without host, and "never" to retain old behavior of always loading props natively.